### PR TITLE
Fix EN title name for shoujo kageki revue starlight

### DIFF
--- a/anime-data.ts
+++ b/anime-data.ts
@@ -1260,7 +1260,7 @@ const data: Data = {
     },
     {
       titleZh: "少女☆歌剧 Revue Starlight",
-      titleEn: "Shōjo☆gekijō Revue Starlight",
+      titleEn: "Shoujo☆Kageki Revue Starlight",
       titleJa: "少女☆歌劇 レヴュースタァライト",
       score: 7.9,
     },


### PR DESCRIPTION
EN name for 少女☆歌劇 レヴュースタァライト is commonly Shoujo☆Kageki Revue Starlight (alternatively Shoujo -> Shōjo), the current name Shōjo☆gekijō Revue Starlight is the 2021 movie release


reference: https://myanimelist.net/anime/40664/Shoujo%E2%98%86Kageki_Revue_Starlight_Movie