### PR TITLE
Corrected typo for English and Japanese anime names

### DIFF
--- a/anime-data.ts
+++ b/anime-data.ts
@@ -1849,7 +1849,7 @@ const data: Data = {
     },
     {
       titleZh: "失忆投捕",
-      titleEn: "The Elusive Samurai",
+      titleEn: "Oblivion Battery",
       titleJa: "忘却バッテリー",
       score: 7.9,
     },
@@ -1862,7 +1862,7 @@ const data: Data = {
     {
       titleZh: "悲喜渔生",
       titleEn: "Fisherman's Songs",
-      titleJa: "悲喜漁生",
+      titleJa: "ネガポジアングラー",
       score: 7.3,
     },
     {
@@ -1873,8 +1873,8 @@ const data: Data = {
     },
     {
       titleZh: "缘结甘神家",
-      titleEn: "The Elusive Samurai",
-      titleJa: "結婚甘神家",
+      titleEn: "Tying the Knot with an Amagami Sister",
+      titleJa: "甘神さんちの縁結び",
       score: 5.9,
     },
   ],


### PR DESCRIPTION
## Corrected typos for Japanese and English names as the last block on the chart had inconsistent anime names for JP, EN and ZH as seen here :
![image](https://github.com/user-attachments/assets/4a3bd1f0-7b76-48b5-8a55-109cbc60f0f4)
![image](https://github.com/user-attachments/assets/3c2cf825-4f44-42a3-a0e3-3dbd85367b66)

Changed "失忆投捕" EN name to "Oblivion Battery"

## Corrected mismatch in JP and EN names in anime-data.ts
 "缘结甘神家" JP name to   "甘神さんちの縁結び", EN name to "Tying the Knot with an Amagami Sister"
 "悲喜渔生" JP name to "ネガポジアングラー", EN name to "Negative Positive Angler"
 