### PR TITLE
Add 'Eden of the East' to 2009 anime data

### DIFF
--- a/anime-data.ts
+++ b/anime-data.ts
@@ -322,6 +322,12 @@ const data: Data = {
       titleJa: "君に届け",
       score: 7.6,
     },
+    {
+      titleZh: "东之伊甸",
+      titleEn: "Eden of the East",
+      titleJa: "東のエデン",
+      score: 7.5,
+    },
   ],
   "2010": [
     {


### PR DESCRIPTION
用《东之伊甸》补全2009年的一个空位